### PR TITLE
コメントの右クリック時の問題の修正

### DIFF
--- a/MultiCommentViewer/ViewModels/MainViewModel.cs
+++ b/MultiCommentViewer/ViewModels/MainViewModel.cs
@@ -1385,16 +1385,17 @@ namespace MultiCommentViewer
             {
                 return null;
             }
-            var match = Regex.Match(message, "(https?://([\\w-]+.)+[\\w-]+(?:/[\\w- ./?%&=]))?");
+            var match = Regex.Match(message, @"https?://[\w.-]+(?:/[\w./?%&=-]*)?");
             if (match.Success)
             {
-                return match.Groups[1].Value;
+                return match.Value;
             }
             return null;
         }
         private void OpenUrl()
         {
             var url = GetUrlFromSelectedComment();
+            if (url == null) return;
             Process.Start(url);
             SetSystemInfo("open: " + url, InfoType.Debug);
         }

--- a/MultiCommentViewer/Views/CommentDataGrid.xaml
+++ b/MultiCommentViewer/Views/CommentDataGrid.xaml
@@ -62,7 +62,7 @@
                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="{Binding SelectedRowForeColor}"/>
                 <ContextMenu x:Key="commentContext" DataContext="{Binding DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}">
                     <MenuItem Header="コメントをコピー" Command="{Binding CommentCopyCommand}" />
-                    <MenuItem Header="URLを開く" IsEnabled="{Binding ContainsUrl}" Command="{Binding OpenUrlCommand}" />
+                    <MenuItem Header="URLを開く" Command="{Binding OpenUrlCommand}" />
                     <MenuItem Header="日本語に翻訳する" Command="{Binding TranslateCommand}" />
                     <Separator />
                     <MenuItem x:Name="UserInfoMenuItem" Header="ユーザ情報" Command="{Binding ShowUserInfoCommand}" />


### PR DESCRIPTION
#12
右クリック時の問題を修正します
a. 右クリックしたコメントがURLを含む場合にフリーズする問題の修正
b. コンテキストメニューの表示状態が最初に右クリックした項目に固定される問題の修正

b の問題についてはコンテキストメニューの表示状態が項目に依存する箇所を削除しました