### PR TITLE
コメントのコンテキストメニューのContext修正

### DIFF
--- a/MultiCommentViewer/ViewModels/MainViewModel.cs
+++ b/MultiCommentViewer/ViewModels/MainViewModel.cs
@@ -1375,7 +1375,9 @@ namespace MultiCommentViewer
         }
         private string GetUrlFromSelectedComment()
         {
-            var selectedComment = SelectedComment;
+            // CopyComment と同じ理由
+            var commentDataGrid = GetActiveWindowContextAsCommentDataGrid();
+            var selectedComment = commentDataGrid.SelectedComment;
             if (selectedComment == null)
             {
                 return null;
@@ -1401,13 +1403,26 @@ namespace MultiCommentViewer
         }
         private void CopyComment()
         {
-            var message = SelectedComment.MessageItems.ToText();
+            // 本当はこのModel (this) が CommentDataGridViewModelBase を継承しているのでこんなのは不要だが
+            // CommentDataGrid 用のコードが UserView に無いのでこうなっている (中途半端な共通化の埋め合わせ)
+            var commentDataGrid = GetActiveWindowContextAsCommentDataGrid();
+
+            var message = commentDataGrid.SelectedComment.MessageItems.ToText();
             try
             {
                 System.Windows.Clipboard.SetText(message);
             }
             catch (System.Runtime.InteropServices.COMException) { }
             SetSystemInfo("copy: " + message, InfoType.Debug);
+        }
+        
+        private static CommentDataGridViewModelBase GetActiveWindowContextAsCommentDataGrid()
+        {
+            var activeWindow = Application.Current.Windows
+                .OfType<Window>()
+                .SingleOrDefault(x => x.IsActive);
+
+            return activeWindow.DataContext as CommentDataGridViewModelBase;
         }
         #region ConnectionsView
         #region ConnectionsViewSelection

--- a/MultiCommentViewer/Views/CommentDataGrid.xaml
+++ b/MultiCommentViewer/Views/CommentDataGrid.xaml
@@ -60,7 +60,7 @@
                 <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="{Binding SelectedRowForeColor}" />
                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="{Binding SelectedRowBackColor}"/>
                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="{Binding SelectedRowForeColor}"/>
-                <ContextMenu x:Key="commentContext" DataContext="{Binding DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}">
+                <ContextMenu x:Key="commentContext" Opened="ContextMenu_Opened">
                     <MenuItem Header="コメントをコピー" Command="{Binding CommentCopyCommand}" />
                     <MenuItem Header="URLを開く" Command="{Binding OpenUrlCommand}" />
                     <MenuItem Header="日本語に翻訳する" Command="{Binding TranslateCommand}" />

--- a/MultiCommentViewer/Views/CommentDataGrid.xaml.cs
+++ b/MultiCommentViewer/Views/CommentDataGrid.xaml.cs
@@ -46,7 +46,12 @@ namespace MultiCommentViewer
             };
         }
 
-
+        private void ContextMenu_Opened(object sender, RoutedEventArgs e)
+        {
+            if (sender is ContextMenu contextMenu) {
+                contextMenu.DataContext = Application.Current.MainWindow.DataContext;
+            }
+        }
 
         public bool IsShowUserInfoMenuItem
         {


### PR DESCRIPTION
#10 
CommentDataGrid (`MultiCommentViewer\Views\CommentDataGrid.xaml`) の コメントの右クリックメニュー (`commentContext`) の `DataContext` の修正です

今までは `FindAncestor` でWindowを検索していましたがこれをやめ、
右クリック時にイベントを実行、コードベースでContextを設定するようにしました